### PR TITLE
Alphabetise task lists

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -8,6 +8,12 @@
         android:entryValues="@array/days_index"
         android:dialogTitle="Week starts on" />
     <CheckBoxPreference
+        android:key="alphabetise_tasks"
+        android:title="List Tasks Alphabetically"
+        android:summaryOff="Tasks are listed in the order you created them, with billables first (requires restart)"
+        android:summaryOn="Tasks are listed alphabetically, with billables first (requires restart)"
+        android:defaultValue="true"/>
+    <CheckBoxPreference
         android:key="weekly_billable_only"
         android:title="Show Only Billable Tasks"
         android:summaryOff="All tasks are shown in the weekly view and exported to CSV"

--- a/src/com/tastycactus/timesheet/TimeEntryEditActivity.java
+++ b/src/com/tastycactus/timesheet/TimeEntryEditActivity.java
@@ -21,8 +21,10 @@ import android.app.Activity;
 import android.app.DatePickerDialog;
 import android.app.Dialog;
 import android.app.TimePickerDialog;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.view.View;
 import android.widget.Button;
 import android.widget.DatePicker;
@@ -167,6 +169,7 @@ public class TimeEntryEditActivity extends Activity {
     public void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
+        SharedPreferences prefs=PreferenceManager.getDefaultSharedPreferences(this);
 
         m_db = new TimesheetDatabase(this);
 
@@ -180,7 +183,7 @@ public class TimeEntryEditActivity extends Activity {
             m_data = new TimeEntryData();
         }
 
-        Cursor task_cursor = m_db.getTasks();
+        Cursor task_cursor = m_db.getTasks(prefs.getBoolean("alphabetise_tasks", true));
 
         setContentView(R.layout.time_entry_edit);
 

--- a/src/com/tastycactus/timesheet/TimesheetActivity.java
+++ b/src/com/tastycactus/timesheet/TimesheetActivity.java
@@ -56,9 +56,10 @@ public class TimesheetActivity extends ListActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        SharedPreferences prefs=PreferenceManager.getDefaultSharedPreferences(this);
 
         m_db = new TimesheetDatabase(this);
-        m_task_cursor = m_db.getTasks();
+        m_task_cursor = m_db.getTasks(prefs.getBoolean("alphabetise_tasks", true));
         startManagingCursor(m_task_cursor);
 
         setContentView(R.layout.main);
@@ -80,7 +81,9 @@ public class TimesheetActivity extends ListActivity {
         registerForContextMenu(getListView());
 
         // Set preference defaults if they haven't been set
-        SharedPreferences prefs=PreferenceManager.getDefaultSharedPreferences(this);
+        if (!prefs.contains("alphabetise_tasks")) {
+            prefs.edit().putBoolean("alphabetise_tasks", true);
+        }
         if (!prefs.contains("weekly_billable_only")) {
             prefs.edit().putBoolean("weekly_billable_only", true);
         }

--- a/src/com/tastycactus/timesheet/TimesheetAppWidgetProvider.java
+++ b/src/com/tastycactus/timesheet/TimesheetAppWidgetProvider.java
@@ -90,7 +90,7 @@ public class TimesheetAppWidgetProvider extends AppWidgetProvider
             // task_id could be an id that has since been deleted
             if (task_id == -1 || !m_db.isValidTask(task_id)) {
                 if (current_id == 0) {
-                    task_id = m_db.getFirstTaskId();
+                    task_id = m_db.getFirstTaskId(m_prefs.getBoolean("alphabetise_tasks", true));
                 } else {
                     task_id = current_id;
                 }

--- a/src/com/tastycactus/timesheet/TimesheetAppWidgetProvider.java
+++ b/src/com/tastycactus/timesheet/TimesheetAppWidgetProvider.java
@@ -186,7 +186,7 @@ public class TimesheetAppWidgetProvider extends AppWidgetProvider
         public void onHandleIntent(Intent intent) {
             long task_id = m_prefs.getLong("app_task", -1);
             long next_task_id = -1;
-            Cursor c = m_db.getTasks();
+            Cursor c = m_db.getTasks(m_prefs.getBoolean("alphabetise_tasks", true));
             while (!c.isAfterLast()) {
                 long c_task_id = c.getLong(c.getColumnIndex("_id"));
                 if (c_task_id == task_id) {

--- a/src/com/tastycactus/timesheet/TimesheetDatabase.java
+++ b/src/com/tastycactus/timesheet/TimesheetDatabase.java
@@ -92,15 +92,22 @@ public class TimesheetDatabase extends SQLiteOpenHelper {
         }
     }
 
-    public Cursor getTasks() {
+    public Cursor getTasks(boolean alphabetiseTasks) {
         SQLiteDatabase db = getReadableDatabase();
-        Cursor c = db.query("tasks", new String[] {"_id", "title", "billable"}, "hidden != 1", null, null, null, "billable DESC, _id ASC");
+
+        // alphabetise_tasks
+        String sortString = "billable DESC, _id ASC";
+        if (alphabetiseTasks == true) {
+            sortString = "billable DESC, title ASC";
+        }
+
+        Cursor c = db.query("tasks", new String[] {"_id", "title", "billable"}, "hidden != 1", null, null, null, sortString);
         c.moveToFirst();
         return c;
     }
 
     public long getFirstTaskId() {
-        Cursor c = getTasks();
+        Cursor c = getTasks(false);
         if (c.getCount() > 0) {
             return c.getLong(0);
         } else {

--- a/src/com/tastycactus/timesheet/TimesheetDatabase.java
+++ b/src/com/tastycactus/timesheet/TimesheetDatabase.java
@@ -106,8 +106,8 @@ public class TimesheetDatabase extends SQLiteOpenHelper {
         return c;
     }
 
-    public long getFirstTaskId() {
-        Cursor c = getTasks(false);
+    public long getFirstTaskId(boolean alphabetise_tasks) {
+        Cursor c = getTasks(alphabetise_tasks);
         if (c.getCount() > 0) {
             return c.getLong(0);
         } else {


### PR DESCRIPTION
Hi,

Nice app; simple, tidy, and although I'm not a freelancer but am just using it to track my daily time generally I've found it to do the job nicely.

Would you like to have the task list sorted so some users can find a task a little easier than when they added it?

I've added a preference and used it when fetching all tasks from the db, both in the main view and the time edit selector. The only gotcha is that it needs the list / app to be closed and re-opened, but I don't think users would change it all that often for it to become a nuisance.

Below is a few screenshots of:
- the bilable>title sorted list and in the time edit screen
- the preference enabled & disabled
- the billable>id sorted list (i.e. original functionality)

![1-list-unsorted](https://f.cloud.github.com/assets/193455/594789/8f003014-cab4-11e2-9860-91403dbae4b3.png) ![2-edit-sorted](https://f.cloud.github.com/assets/193455/594790/8f0a707e-cab4-11e2-9a3a-1a68395b8b03.png)
![3-pref-on](https://f.cloud.github.com/assets/193455/594787/8ee96636-cab4-11e2-95c4-f9168a97b695.png) ![4-pref-off](https://f.cloud.github.com/assets/193455/594788/8efdc734-cab4-11e2-880d-98f1a5033bd3.png)
![5-list-sorted](https://f.cloud.github.com/assets/193455/594786/8ed0246e-cab4-11e2-988d-57a1431a4f2a.png) 

Cheers.
